### PR TITLE
Fixed the filter condition in the PUT route for User collection

### DIFF
--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -107,7 +107,7 @@ router.put("/", authMiddleware, async (req, res) => {
     }
 
     await User.updateOne(req.body, {
-        id: req.userId
+        _id: req.userId
     })
 
     res.json({


### PR DESCRIPTION
The filter condition (shown below) used to update User collection in PUT route handler was giving '"Updated successfully" response but under the hood it was not updating the respective record in the MongoDB.
```
await User.findOneAndUpdate(req.body, {
    id: req.userId
  });
```
There is a small typo in the filter **id** we are passing, it should be **_id**.

**Solution** : 
The filter condition should be modified as shown below : 
```
await User.findOneAndUpdate(req.body, {
    _id: req.userId
  });
```
P.S : I know it's a simple fix 👍, but felt like pointing out if you are worrying like me why records didn't update in MongoDB